### PR TITLE
Tweak to webhook tag

### DIFF
--- a/src/tags/webhook.js
+++ b/src/tags/webhook.js
@@ -50,7 +50,7 @@ e.execute = async function (params) {
                 username: params.args[5],
                 avatarURL: params.args[6],
                 content: params.args[3] || '',
-                embeds: embed && util.isArray(embed) ? embed : (embed ? [embed] : [])
+                embeds: embed ? (util.isArray(embed) ? embed : [embed]) : []
             });
         } catch (err) {
             replaceString = bu.tagProcessError(params, `\`Error executing webhook: ${err.message}\``)

--- a/src/tags/webhook.js
+++ b/src/tags/webhook.js
@@ -50,7 +50,7 @@ e.execute = async function (params) {
                 username: params.args[5],
                 avatarURL: params.args[6],
                 content: params.args[3] || '',
-                embeds: embed ? [embed] : []
+                embeds: embed && util.isArray(embed) ? embed : (embed ? [embed] : []);
             });
         } catch (err) {
             replaceString = bu.tagProcessError(params, `\`Error executing webhook: ${err.message}\``)

--- a/src/tags/webhook.js
+++ b/src/tags/webhook.js
@@ -50,7 +50,7 @@ e.execute = async function (params) {
                 username: params.args[5],
                 avatarURL: params.args[6],
                 content: params.args[3] || '',
-                embeds: embed && util.isArray(embed) ? embed : (embed ? [embed] : []);
+                embeds: embed && util.isArray(embed) ? embed : (embed ? [embed] : [])
             });
         } catch (err) {
             replaceString = bu.tagProcessError(params, `\`Error executing webhook: ${err.message}\``)


### PR DESCRIPTION
Added support for multi embeds
`{webhook;id;token;content;embeds}` where embeds can be an array of objects `[{embed1},{embed2}]`