### PR TITLE
Update switch.js

### DIFF
--- a/src/tags/switch.js
+++ b/src/tags/switch.js
@@ -41,7 +41,14 @@ e.execute = async function(params) {
     args.shift();
     for (let i = 0; i < args.length; i++) {
         if (i != args.length - 1) {
-            cases[args[i]] = args[i + 1];
+            let deserialized = bu.deserializeTagArray(args[i]);
+            if (deserialized && Array.isArray(deserialized.v)) {
+                for (let j = 0, j < deserialized.v.length, j++) {
+                    cases[deserialized[j]] = args[i + 1];
+                }
+            } else {
+                cases[args[i]] = args[i + 1];
+            }
             i++;
         } else {
             elseDo = args[i];

--- a/src/tags/switch.js
+++ b/src/tags/switch.js
@@ -44,7 +44,7 @@ e.execute = async function(params) {
             let deserialized = bu.deserializeTagArray(args[i]);
             if (deserialized && Array.isArray(deserialized.v)) {
                 for (let j = 0, j < deserialized.v.length, j++) {
-                    cases[deserialized[j]] = args[i + 1];
+                    cases[deserialized.v[j]] = args[i + 1];
                 }
             } else {
                 cases[args[i]] = args[i + 1];


### PR DESCRIPTION
Added switch support for arrays in the %2 == 0 argument positions
If an argument is an array, expand the array into the logical equivalent of
```
switch (args[1]) {
   case args[2][0]:
   case args[2][1]:
   case args[2][2]:
      args[3];
      break;
    .......
}
```